### PR TITLE
Fix download method

### DIFF
--- a/apkpure/apkpure.py
+++ b/apkpure/apkpure.py
@@ -206,9 +206,7 @@ class ApkPure:
 
     # TODO Fix this downloader method
     def downloader(self, url: str) -> str:
-        response = requests.get(
-            url, stream=True, allow_redirects=True, headers=self.headers
-        )
+        response = self.get_response(url = url , stream=True, allow_redirects=True, headers=self.headers)
 
         d = response.headers.get("content-disposition")
         fname = re.findall("filename=(.+)", d)[0].strip('"')


### PR DESCRIPTION
The previous fix didn't work for all possible scenarios. This new fix uses a previous method to handle the 403 error code when attempting to download.

The problem was that the downloader method made new requests directly to the server. So, if a user encountered a 403 error (blocked request) while trying to search, the previous fix ensured it would work. However, since the downloader method made new requests without going through the get_response method (responsible for response management), the error persisted.

To resolve this, a bypass was implemented to correct the issue, ensuring that all requests from the downloader go through the get_response method.